### PR TITLE
feature/111 브라우저에서 와일드카드를 쓴 cors를 막아서 명시적으로 로컬호스트3000포트 선언

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -236,8 +236,13 @@ CELERY_RESULT_SERIALIZER = "json"
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
-CORS_ALLOW_ALL_ORIGINS = True
-# CORS_ALLOW_ORIGINS = "*" 같은 의미
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost:3000",
+]
+CORS_ALLOW_CREDENTIALS = True
+CSRF_TRUSTED_ORIGINS = [
+    "http://localhost:3000",
+]
 
 if "test" in sys.argv:
     DISABLE_AI_SUMMARY_SIGNAL = True


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #111
- 작업 요약: 브라우저에서 와일드카드를 쓴 cors를 막아서 명시적으로 로컬호스트3000포트 선언.

## 📄 상세 내용
- [ ] settings.py 수정

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
