### PR TITLE
Fix/157- 프론트 요청에 따라서 post를 get으로 변경

### DIFF
--- a/apps/user/views/token_refresh.py
+++ b/apps/user/views/token_refresh.py
@@ -30,10 +30,8 @@ class TokenRefreshWithBlacklistView(APIView):
             401: OpenApiResponse(description="refresh_token 무효/블랙리스트"),
         },
     )
-    def post(self, request):
-        refresh = request.data.get("refresh_token") or request.COOKIES.get(
-            "refresh_token"
-        )
+    def get(self, request):
+        refresh = request.COOKIES.get("refresh_token")
         if not refresh:
             return Response(
                 {"detail": "refresh token 소실"}, status=status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #157 
- 작업 요약: 프론트 요청에 따라서 post를 get으로 변경

## 📄 상세 내용
- [ ] 프론트의 요청에 따라 쿠키에서만 리프레쉬토큰 추출하는 로직을 구현합니다.

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
