### PR TITLE
Bug/164 fix refresh cookie delete

### DIFF
--- a/apps/user/utils/cookies.py
+++ b/apps/user/utils/cookies.py
@@ -1,0 +1,22 @@
+from django.conf import settings
+
+REFRESH_COOKIE_NAME = "refresh_token"
+
+
+def set_refresh_cookie(response, token: str) -> None:
+    response.set_cookie(
+        key=REFRESH_COOKIE_NAME,
+        value=token,
+        httponly=True,
+        samesite="Lax",
+        secure=not settings.DEBUG,
+        path="/",
+    )
+
+
+def delete_refresh_cookie(response) -> None:
+    response.delete_cookie(
+        key=REFRESH_COOKIE_NAME,
+        path="/",
+        samesite="Lax",
+    )

--- a/apps/user/views/LoginView.py
+++ b/apps/user/views/LoginView.py
@@ -5,6 +5,7 @@ from rest_framework import status
 from rest_framework.permissions import AllowAny
 from django.conf import settings
 
+from apps.user.utils.cookies import set_refresh_cookie
 from apps.user.serializers.login import LoginSerializer
 from apps.user.utils.tokens import TokenService
 
@@ -53,13 +54,6 @@ class LoginView(APIView):
             data,
             status=status.HTTP_200_OK,
         )
-        response.set_cookie(
-            key="refresh_token",
-            value=refresh_token,
-            httponly=True,
-            samesite=settings.REFRESH_COOKIE_SAMESITE,
-            secure=settings.REFRESH_COOKIE_SECURE,
-            path="/",
-        )
+        set_refresh_cookie(response, refresh_token)
 
         return response

--- a/apps/user/views/logout.py
+++ b/apps/user/views/logout.py
@@ -5,6 +5,7 @@ from rest_framework.permissions import IsAuthenticated
 from drf_spectacular.utils import extend_schema, OpenApiResponse
 
 from apps.user.utils.tokens import TokenService
+from apps.user.utils.cookies import delete_refresh_cookie, REFRESH_COOKIE_NAME
 
 
 class LogoutView(APIView):
@@ -27,7 +28,7 @@ class LogoutView(APIView):
     def post(self, request):
         svc = TokenService()
 
-        refresh_token = request.COOKIES.get("refresh_token")
+        refresh_token = request.COOKIES.get(REFRESH_COOKIE_NAME)
         if refresh_token:
             svc.blacklist_refresh(refresh_token)
 
@@ -39,5 +40,5 @@ class LogoutView(APIView):
         response = Response(
             {"detail": "로그아웃 되었습니다."}, status=status.HTTP_200_OK
         )
-        response.delete_cookie("refresh_token", path="/")
+        delete_refresh_cookie(response)
         return response

--- a/apps/user/views/profileview.py
+++ b/apps/user/views/profileview.py
@@ -6,6 +6,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from drf_spectacular.utils import extend_schema, OpenApiResponse
 
 from apps.user.serializers.profile import MeSerializer, DeleteUserSerializer
+from apps.user.utils.cookies import delete_refresh_cookie, REFRESH_COOKIE_NAME
 
 
 class MeView(APIView):
@@ -106,7 +107,7 @@ class WithdrawView(APIView):
         user = request.user
 
         # refresh token 블랙리스트
-        refresh_token = request.COOKIES.get("refresh_token")
+        refresh_token = request.COOKIES.get(REFRESH_COOKIE_NAME)
         if refresh_token:
             try:
                 token = RefreshToken(refresh_token)
@@ -120,7 +121,9 @@ class WithdrawView(APIView):
         user.is_active = False
         user.save(update_fields=["email", "password", "is_active"])
 
-        return Response(
+        response = Response(
             {"message": "회원 탈퇴가 완료되었습니다."},
             status=status.HTTP_200_OK,
         )
+        delete_refresh_cookie(response)
+        return response


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #164 
- 작업 요약: 프론트 요청에 따라 refresh를 담고 있는 cookie를 삭제하는 코드를 작성했습니다

## 📄 상세 내용
- [ ] 프론트 요청에 따라 refresh를 담고 있는 cookie를 삭제하는 코드를 작성했습니다

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
